### PR TITLE
restyle switch to better fit ios

### DIFF
--- a/src/screens/profile/PrivacySettingsScreen.js
+++ b/src/screens/profile/PrivacySettingsScreen.js
@@ -69,10 +69,8 @@ const styles = {
     marginBottom: 30
   },
   switchText: {
-    fontSize: 20
-  },
-  switchFlip: {
-    transform: [{ scaleX: 1.2 }, { scaleY: 1.2 }]
+    fontSize: 20,
+    paddingRight: 5
   },
   buttonWrap: {
     backgroundColor: '#FFFFFF',


### PR DESCRIPTION
Switch was too large on ios resulting in overlap. Switch styling removed and padding add to make it look nicer