### PR TITLE
Updated Splitting of Clusters

### DIFF
--- a/src/api/_tests_/matching.test.js
+++ b/src/api/_tests_/matching.test.js
@@ -1,0 +1,38 @@
+import * as matching from '../matching'
+
+it('splitting is done for big clusters', () => {
+  const cluster = {
+    data: [
+      { userId: 'a', vector: [0, 0, 0, 0] },
+      { userId: 'b', vector: [0, 0, 0, 0] },
+      { userId: 'c', vector: [0, 0, 0, 0] },
+      { userId: 'd', vector: [0, 0, 0, 0] },
+      { userId: 'e', vector: [0, 0, 0, 0] },
+      { userId: 'f', vector: [0, 0, 0, 0] },
+      { userId: 'g', vector: [0, 0, 0, 0] },
+      { userId: 'h', vector: [0, 0, 0, 0] }
+    ],
+    mean: [0, 0, 0, 0]
+  }
+
+  expect(matching.splitCluster(cluster)).toEqual([
+    {
+      data: [
+        { userId: 'e', vector: [0, 0, 0, 0] },
+        { userId: 'f', vector: [0, 0, 0, 0] },
+        { userId: 'g', vector: [0, 0, 0, 0] },
+        { userId: 'h', vector: [0, 0, 0, 0] }
+      ],
+      mean: [0, 0, 0, 0]
+    },
+    {
+      data: [
+        { userId: 'a', vector: [0, 0, 0, 0] },
+        { userId: 'b', vector: [0, 0, 0, 0] },
+        { userId: 'c', vector: [0, 0, 0, 0] },
+        { userId: 'd', vector: [0, 0, 0, 0] }
+      ],
+      mean: [0, 0, 0, 0]
+    }]
+  )
+})

--- a/src/api/matching.js
+++ b/src/api/matching.js
@@ -3,6 +3,31 @@ import { getClusters } from './kMeans'
 import { sendPushNotification } from './notifications'
 import { Alert } from 'react-native'
 
+export const splitCluster = (cluster) => {
+  console.log('Splitting...')
+  const mean = cluster.mean
+  const clusterData = cluster.data
+
+  const firstHalf = clusterData.splice(clusterData.length / 2)
+  const result = [{ data: firstHalf, mean: mean }, { data: clusterData, mean: mean }]
+
+  return result.flatMap(x => splitHelper(x))
+}
+
+export const splitHelper = (cluster) => {
+  if (cluster.data.length <= 5) {
+    return [cluster]
+  } else {
+    const clusterMean = cluster.mean
+    const clusterData = cluster.data
+
+    const firstHalf = clusterData.splice(clusterData.length / 2)
+    const result = [{ data: firstHalf, mean: clusterMean }, { data: clusterData, mean: clusterMean }]
+
+    return result.flatMap(x => splitHelper(x))
+  }
+}
+
 export async function formClusters () {
   const data = []
   console.log('Start pulling')
@@ -50,23 +75,6 @@ export async function formClusters () {
 
     const correctedClusters = flattenHelper(incorrectClusters, 0)
     return acceptableClusters.concat(correctedClusters)
-  }
-
-  const splitCluster = (cluster) => {
-    console.log('Splitting...')
-    const firstHalf = cluster.splice(cluster.data.length / 2)
-    const result = [firstHalf, cluster]
-    return result.flatMap(x => splitHelper(x))
-  }
-
-  const splitHelper = (cluster) => {
-    if (cluster.data.length <= 5) {
-      return [cluster]
-    } else {
-      const firstHalf = cluster.splice(cluster.data.length / 2)
-      const result = [firstHalf, cluster]
-      return result.flatMap(x => splitHelper(x))
-    }
   }
 
   const flattenedClusters = flattenClusters(clusters)


### PR DESCRIPTION
Splitting of matching clusters recursively was buggy due to the usage of splice incorrectly. This meant that really big clusters did not split as we expected. 

These changes updated the function to make it work as intended. A test case is also included to properly reflect what our actual firebase data might look like and using that to pass in to the function.